### PR TITLE
start supporting spree 2.4 stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ group :assets do
   gem 'therubyracer'
 end
 
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-2-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-4-stable'
 
 gemspec

--- a/lib/spree_multi_tenant.rb
+++ b/lib/spree_multi_tenant.rb
@@ -42,7 +42,6 @@ module SpreeMultiTenant
       Spree::TaxRate,
       Spree::Taxonomy,
       Spree::Taxon,
-      Spree::TokenizedPermission,
       Spree::Tracker,
       Spree::User,
       Spree::Variant,

--- a/spree_multi_tenant.gemspec
+++ b/spree_multi_tenant.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2.0'
+  s.add_dependency 'spree_core', '~> 2.4.0'
   s.add_dependency 'multitenant'
 
   s.add_development_dependency 'capybara', '~> 2.1'


### PR DESCRIPTION
Currenlty I am working on a Spree project (using spree-2.4 stable). I have tested this in my machine and it works just fine( with one small hack, https://github.com/stefansenk/spree_multi_tenant/issues/14).
`Spree::TokenizedPermission` is no longer available in Spree, hence removed it.
